### PR TITLE
Support EEP37: Funs with names

### DIFF
--- a/src/proper_prop_remover.erl
+++ b/src/proper_prop_remover.erl
@@ -112,6 +112,8 @@ safe_expr({'receive',_Line,Clauses,AfterExpr,AfterBody}) ->
     andalso lists:all(fun safe_expr/1, AfterBody);
 safe_expr({'fun',_Line,{clauses,Clauses}}) ->
     lists:all(fun safe_clause/1, Clauses);
+safe_expr({named_fun,_Line,_Name,Clauses}) ->
+    lists:all(fun safe_clause/1, Clauses);
 safe_expr({'query',_Line,ListCompr}) ->
     safe_expr(ListCompr);
 safe_expr({record_field,_Line,Expr,_FieldName}) ->

--- a/src/proper_transformer.erl
+++ b/src/proper_transformer.erl
@@ -328,6 +328,9 @@ rewrite_expr({'receive',Line,Clauses,AfterExpr,AfterBody}, ModInfo) ->
 rewrite_expr({'fun',Line,{clauses,Clauses}}, ModInfo) ->
     NewClauses = [rewrite_clause(C,ModInfo) || C <- Clauses],
     {'fun',Line,{clauses,NewClauses}};
+rewrite_expr({named_fun,Line,Name,Clauses}, ModInfo) ->
+    NewClauses = [rewrite_clause(C,ModInfo) || C <- Clauses],
+    {named_fun,Line,Name,NewClauses};
 rewrite_expr({'query',Line,ListCompr}, ModInfo) ->
     {'query',Line,rewrite_expr(ListCompr,ModInfo)};
 rewrite_expr({record_field,Line,Expr,FieldName}, ModInfo) ->


### PR DESCRIPTION
R17 will [probably](http://erlang.org/pipermail/eeps/2013-September/000466.html) include [my implementation of EEP37](https://github.com/nox/otp/compare/erlang:maint...eep37) which allows expressions of the form:

``` erlang
fact() ->
    fun Fact(N) when N > 0 -> N * Fact(N - 1); Fact(0) -> 1 end
```

PropEr should be able to cope with these expressions. I would like to test this but I don't know which case I should extend.