### PR TITLE
Make selftests work with R14B01

### DIFF
--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -1149,8 +1149,8 @@ max_size_test() ->
     ?assert(lists:member({prop_identity,0},
 			 perf_max_size:module_info(exports))),
     %% run some tests with a small and a big max_size option
-    {Ts,true} = timer:tc(fun() -> max_size_test_aux(42) end),
-    {Tb,true} = timer:tc(fun() -> max_size_test_aux(16#ffffffff) end),
+    {Ts,true} = timer:tc(fun() -> max_size_test_aux(42) end, []),
+    {Tb,true} = timer:tc(fun() -> max_size_test_aux(16#ffffffff) end, []),
     %% ensure that the test with the big max_size option does not take
     %% much longer than the small one to complete
     ?assert(2*Ts >= Tb).


### PR DESCRIPTION
At the cost of using tc(F, []) instead of tc(F).

R14B01 doesn't even work anymore with the enclosed rebar but it can
be useful for apps using proper that still rely on R14B01, and that
have proper as one of their deps, triggering it to run with `./rebar
eunit`, which otherwise works fine.