### PR TITLE
Prevent crash when encountering the 'any' type argument

### DIFF
--- a/src/proper_typeserver.erl
+++ b/src/proper_typeserver.erl
@@ -1073,7 +1073,7 @@ update_vars({remote_type,Line,[RemModForm,NameForm,ArgForms]}, VarSubstsDict,
 	    UnboundToAny) ->
     NewArgForms = [update_vars(A,VarSubstsDict,UnboundToAny) || A <- ArgForms],
     {remote_type, Line, [RemModForm,NameForm,NewArgForms]};
-update_vars({type,_,tuple,any} = Call, _VarSubstsDict, _UnboundToAny) ->
+update_vars({type,_,_,any} = Call, _VarSubstsDict, _UnboundToAny) ->
     Call;
 update_vars({type,Line,Name,ArgForms}, VarSubstsDict, UnboundToAny) ->
     {type, Line, Name, [update_vars(A,VarSubstsDict,UnboundToAny)
@@ -1649,7 +1649,8 @@ convert(Mod, {type,_,Name,[]}, State, Stack, VarDict) ->
 	false ->
 	    convert_maybe_hard_adt(Mod, Name, [], State, Stack, VarDict)
     end;
-convert(Mod, {type,_,Name,ArgForms}, State, Stack, VarDict) ->
+convert(Mod, {type,_,Name,ArgForms}, State, Stack, VarDict)
+  when is_list(ArgForms) ->
     convert_maybe_hard_adt(Mod, Name, ArgForms, State, Stack, VarDict);
 convert(_Mod, TypeForm, _State, _Stack, _VarDict) ->
     {error, {unsupported_type,TypeForm}}.


### PR DESCRIPTION
This fixes #94 in which proper_typeserver would crash when resolving the
'erlang:timestamp()' type in OTP 17.x.

The underlying problem is that we were encountering the 'map()' type in
the erlang module with an argument of 'any'. At this point, the
typeserver only knew how to handle this situation for tuples.

Support has been extended to properly handle this argument for other
types, and the 'map()' type will now correctly be identified as
unsupported rather than causing a crash.

For example:

1> proper_typeserver:demo_translate_type(erlang, "map()").
{error,{unsupported_type,{type,1,map,any}}}