### PR TITLE
Generate compile_flags.hrl also on GNU/Hurd

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -33,7 +33,7 @@
 	    warn_obsolete_guard, warn_unused_import,
 	    warn_missing_spec, warn_untyped_record]}.
 
-{pre_hooks, [{"(linux|darwin|solaris)", compile, "make include/compile_flags.hrl"},
+{pre_hooks, [{"(linux|darwin|solaris|gnu)", compile, "make include/compile_flags.hrl"},
              {"(freebsd|netbsd|openbsd)", compile, "gmake include/compile_flags.hrl"},
 		{"win32", compile, "escript.exe write_compile_flags include/compile_flags.hrl"}]}.
 {post_hooks, [{clean, "./clean_doc.sh"}]}.


### PR DESCRIPTION
It is a Unix platform using GNU make, so PropEr can be built there too.