### PR TITLE
try to fix non-proper lists in state

### DIFF
--- a/src/proper_statem.erl
+++ b/src/proper_statem.erl
@@ -769,8 +769,8 @@ arg_defined({var,I} = V, SymbEnv) when is_integer(I) ->
     lists:member(V, SymbEnv);
 arg_defined(Tuple, SymbEnv) when is_tuple(Tuple) ->
     args_defined(tuple_to_list(Tuple), SymbEnv);
-arg_defined(List, SymbEnv) when is_list(List) ->
-    args_defined(List, SymbEnv);
+arg_defined([Head|Tail], SymbEnv) ->
+    arg_defined(Head, SymbEnv) andalso arg_defined(Tail, SymbEnv);
 arg_defined(_, _) ->
     true.
 

--- a/test/lists_statem.erl
+++ b/test/lists_statem.erl
@@ -1,0 +1,29 @@
+-module(lists_statem).
+-compile(export_all).
+
+-include_lib("proper/include/proper.hrl").
+
+initial_state() ->
+    state.
+
+command(_State) ->
+    return({call, ?MODULE, foo, [[a|b]]}).
+
+precondition(_, _) ->
+    true.
+
+next_state(State, _, _) ->
+    State.
+
+postcondition(_, _, _) ->
+    true.
+
+foo(_Something) ->
+    ok.
+
+prop_simple() ->
+    ?FORALL(Cmds, commands(?MODULE),
+	    begin
+		{_H,_S,Res} = run_commands(?MODULE, Cmds),
+		equals(Res, ok)
+	    end).

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -858,8 +858,8 @@ true_props_test_() ->
      {timeout, 20, ?_passes(symb_statem:prop_parallel_simple())},
      {timeout, 10, ?_passes(ets_statem:prop_ets())},
      {timeout, 20, ?_passes(ets_statem:prop_parallel_ets())},
-     {timeout, 20, ?_passes(pdict_fsm:prop_pdict())}],
-     ?_passes(lists_statem:prop_simple()).
+     {timeout, 20, ?_passes(pdict_fsm:prop_pdict())},
+     ?_passes(lists_statem:prop_simple())].
 
 false_props_test_() ->
     [?_failsWith([[_Same,_Same]],

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -858,7 +858,8 @@ true_props_test_() ->
      {timeout, 20, ?_passes(symb_statem:prop_parallel_simple())},
      {timeout, 10, ?_passes(ets_statem:prop_ets())},
      {timeout, 20, ?_passes(ets_statem:prop_parallel_ets())},
-     {timeout, 20, ?_passes(pdict_fsm:prop_pdict())}].
+     {timeout, 20, ?_passes(pdict_fsm:prop_pdict())}],
+     ?_passes(lists_statem:prop_simple()).
 
 false_props_test_() ->
     [?_failsWith([[_Same,_Same]],


### PR DESCRIPTION
I encountered the problem a few times that I cannot have non-proper lists in my symbolic state.  As I like to use a dictionary which might include non-proper lists, I made this little fix.  It works for me.  As far as I can tell it doesn't break anything.