### PR TITLE
Shrinking takes forever in proper_gen:sampleshrink/1

### DIFF
--- a/src/proper_gen.erl
+++ b/src/proper_gen.erl
@@ -276,7 +276,14 @@ keep_shrinking(ImmInstance, Acc, Type, State) ->
 	    %% try next shrinker
 	    keep_shrinking(ImmInstance, Acc, Type, NewState);
 	{[Shrunk|_Rest], _NewState} ->
-	    keep_shrinking(Shrunk, [ImmInstance|Acc], Type)
+        Acc2 = [ImmInstance|Acc],
+        case lists:member(Shrunk, Acc2) of
+            true ->
+                %% Avoid infinite loops
+                lists:reverse(Acc2);
+            false ->
+                keep_shrinking(Shrunk, Acc2, Type)
+        end
     end.
 
 -spec contains_fun(term()) -> boolean().

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -1168,6 +1168,17 @@ dollar_only_cp_test_() ->
 	     re:run(atom_to_list(K), ["^[$]"], [{capture,none}]) =:= match]).
 
 
+sampleshrink_test_() ->
+    [{"Test type with restrain",
+      [{"Try another way to call shrinking (not sampleshrink)",
+        ?_shrinksTo([a], non_empty(?LET({Len,List},
+                                        {range(0,5), list(a)},
+                                        lists:sublist(List, Len))))},
+       ?_test(proper_gen:sampleshrink(non_empty(?LET({Len,List},
+                                       {range(0,5), list(a)},
+                                       lists:sublist(List, Len)))))]}].
+
+
 %%------------------------------------------------------------------------------
 %% Performance tests
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
This command runs in infinite loop:

```erlang
proper_gen:sampleshrink(proper_types:non_empty(proper_types:bind({proper_types:range(0,5), proper_types:list(proper_types:byte())},
fun({L,X})-> io:format("~p:~p~n", [L,X]), lists:sublist(X, L) end, false))). 
```

Or the same with macros:
```erlang
non_empty(?LET({Len,List}, {proper:range(0,5), list(byte)},lists:sublist(List, Len)))
```

Output:

```erlang
0:[237,44,129,39]
1:[237,44,129,39]
0:[237,44,129,39]
1:[237,44,129,39]
0:[237,44,129,39]
1:[237,44,129,39]
0:[237,44,129,39]
1:[237,44,129,39]
```

Shrinking with `FORALL(X,T,false)` works fine for this value even without the patch.