### PR TITLE
Enabling ?LET macros to use user defined types

### DIFF
--- a/src/proper_transformer.erl
+++ b/src/proper_transformer.erl
@@ -276,6 +276,12 @@ rewrite_expr({call,Line,
     NewRawType = rewrite_type(RawType, ModInfo),
     NewProp = rewrite_expr(Prop, ModInfo),
     {call,Line,FunRef,[NewRawType,NewProp]};
+rewrite_expr({call, Line,
+              {remote,_,{atom,_,proper_types}, {atom, _, bind}} = FunRef,
+              [RawType, Gen, ShrinkToParts]}, ModInfo) ->
+    NewRawType = rewrite_type(RawType, ModInfo),
+    NewGen = rewrite_expr(Gen, ModInfo),
+    {call, Line, FunRef, [NewRawType,NewGen, ShrinkToParts]};
 rewrite_expr({call,Line,FunRef,Args}, ModInfo) ->
     NewFunRef = rewrite_expr(FunRef, ModInfo),
     NewArgs = [rewrite_expr(A,ModInfo) || A <- Args],

--- a/test/let_tests.erl
+++ b/test/let_tests.erl
@@ -1,4 +1,4 @@
-%%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
+%%% Copyright 2010-2016 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
 %%%
@@ -17,16 +17,25 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2010-2011 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
+%%% @copyright 2010-2016 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}
 %%% @author Manolis Papadakis
 %%% @doc This module tests whether native types are parsed outside of ?FORALLs.
 
--module(no_out_of_forall_test).
+-module(let_tests).
 -export([]).
 
 -include_lib("proper/include/proper.hrl").
 
-foo() -> ?LET(X, types_test1:exp1(), {42,X}).
+foo_t() ->
+    ?LET(X, types_test1:exp1(), {42,X}).
 
-prop_1() -> ?FORALL(_, foo(), true).
+prop_1() ->
+    ?FORALL(_, foo_t(), true).
+
+-type rng() :: 17..54.
+bar_t() ->
+    ?LET(N, rng(), 3*N).
+
+prop_2() ->
+    ?FORALL(N, bar_t(), N < 124).

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -743,7 +743,7 @@ parse_transform_test_() ->
     [?_passes(auto_export_test1:prop_1()),
      ?_assertError(undef, auto_export_test2:prop_1()),
      ?_assertError(undef, no_native_parse_test:prop_1()),
-     ?_assertError(undef, no_out_of_forall_test:prop_1())].
+     ?_passes(no_out_of_forall_test:prop_1())].
 
 native_type_props_test_() ->
     [?_passes(?FORALL({X,Y}, {my_native_type(),my_proper_type()},

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -1,4 +1,4 @@
-%%% Copyright 2010-2015 Manolis Papadakis <manopapad@gmail.com>,
+%%% Copyright 2010-2016 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
 %%%
@@ -17,7 +17,7 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2010-2015 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
+%%% @copyright 2010-2016 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}
 %%% @author Manolis Papadakis
 %%% @doc This modules contains PropEr's Unit tests. You need the EUnit
@@ -743,7 +743,8 @@ parse_transform_test_() ->
     [?_passes(auto_export_test1:prop_1()),
      ?_assertError(undef, auto_export_test2:prop_1()),
      ?_assertError(undef, no_native_parse_test:prop_1()),
-     ?_passes(no_out_of_forall_test:prop_1())].
+     ?_passes(let_tests:prop_1()),
+     ?_failsWith([3*42], let_tests:prop_2())].
 
 native_type_props_test_() ->
     [?_passes(?FORALL({X,Y}, {my_native_type(),my_proper_type()},


### PR DESCRIPTION
This fixes an issue where ?LET could not use user defined types like this:

    -type my_type() :: integer().
    even_numbers() ->
        ?LET(I, my_type(), I*2).
