### PR TITLE
maps: support in symbolic vars

### DIFF
--- a/src/proper_symb.erl
+++ b/src/proper_symb.erl
@@ -295,13 +295,29 @@ symb_walk_call(VarValues, Mod, Fun, Args,
     HandleCall(Mod, Fun, HandledArgs).
 
 -spec symb_walk_gen(var_values(), symb_term(), handle_info()) -> handled_term().
+-ifdef(AT_LEAST_17).
 symb_walk_gen(VarValues, SymbTerm,
-	      {_Caller,_HandleCall,HandleTerm} = HandleInfo) ->
+              {_Caller,_HandleCall,HandleTerm} = HandleInfo) ->
     SymbWalk = fun(X) -> symb_walk(VarValues, X, HandleInfo) end,
     Term =
-	if
-	    is_list(SymbTerm)  -> proper_arith:safe_map(SymbWalk, SymbTerm);
-	    is_tuple(SymbTerm) -> proper_arith:tuple_map(SymbWalk, SymbTerm);
-	    true               -> SymbTerm
-	end,
+        if
+            is_list(SymbTerm)  -> proper_arith:safe_map(SymbWalk, SymbTerm);
+            is_tuple(SymbTerm) -> proper_arith:tuple_map(SymbWalk, SymbTerm);
+            is_map(SymbTerm)   -> maps:from_list(
+                                    proper_arith:safe_map(SymbWalk, maps:to_list(SymbTerm))
+                                   );
+            true               -> SymbTerm
+        end,
     HandleTerm(Term).
+-else.
+symb_walk_gen(VarValues, SymbTerm,
+              {_Caller,_HandleCall,HandleTerm} = HandleInfo) ->
+    SymbWalk = fun(X) -> symb_walk(VarValues, X, HandleInfo) end,
+    Term =
+        if
+            is_list(SymbTerm)  -> proper_arith:safe_map(SymbWalk, SymbTerm);
+            is_tuple(SymbTerm) -> proper_arith:tuple_map(SymbWalk, SymbTerm);
+            true               -> SymbTerm
+        end,
+    HandleTerm(Term).
+-endif.


### PR DESCRIPTION
Fix for part 3 of https://github.com/manopapad/proper/issues/118

Any plan on supporting OTP > 17?

I encountered the issue solved when writing a proper_statem that get/set'ed maps.
More precisely, `next_state/3`'s `V` was applied `{call,...}`s to extract values that were then stored in a map (then stored in a `state` record).

However in subsequent runs of commands, the symbolic calls would never be turned into "dynamic values". Errors such as `badarg: ++/2 can't work on {call,maps,get,[k,#{k=>v}]} []`

This does not solve the whole "support maps" issue, nor is the fastest implementation.