### PR TITLE
Make next_state/3 handle maps

### DIFF
--- a/src/proper_symb.erl
+++ b/src/proper_symb.erl
@@ -299,10 +299,26 @@ symb_walk_call(VarValues, Mod, Fun, Args,
 symb_walk_gen(VarValues, SymbTerm,
 	      {_Caller,_HandleCall,HandleTerm} = HandleInfo) ->
     SymbWalk = fun(X) -> symb_walk(VarValues, X, HandleInfo) end,
-    Term =
-	if
-	    is_list(SymbTerm)  -> proper_arith:safe_map(SymbWalk, SymbTerm);
-	    is_tuple(SymbTerm) -> proper_arith:tuple_map(SymbWalk, SymbTerm);
-	    true               -> SymbTerm
-	end,
+    Term = do_symb_walk_gen(SymbWalk, SymbTerm),
     HandleTerm(Term).
+
+-spec do_symb_walk_gen(fun((T) -> S), maybe_improper_list(T,T | [])) ->
+			  maybe_improper_list(S,S | []).
+-ifdef(AT_LEAST_17).
+do_symb_walk_gen(SymbWalk, SymbTerm) when is_map(SymbTerm) ->
+	maps:from_list(
+	  proper_arith:safe_map(SymbWalk, maps:to_list(SymbTerm)));
+do_symb_walk_gen(SymbWalk, SymbTerm) when is_list(SymbTerm) ->
+	proper_arith:safe_map(SymbWalk, SymbTerm);
+do_symb_walk_gen(SymbWalk, SymbTerm) when is_tuple(SymbTerm) ->
+	proper_arith:tuple_map(SymbWalk, SymbTerm);
+do_symb_walk_gen(_, SymbTerm) ->
+	SymbTerm.
+-else.
+do_symb_walk_gen(SymbWalk, SymbTerm) when is_list(SymbTerm) ->
+	proper_arith:safe_map(SymbWalk, SymbTerm);
+do_symb_walk_gen(SymbWalk, SymbTerm) when is_tuple(SymbTerm) ->
+	proper_arith:tuple_map(SymbWalk, SymbTerm);
+do_symb_walk_gen(_, SymbTerm) ->
+	SymbTerm.
+-endif.

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -893,6 +893,12 @@ true_props_test_() ->
      {timeout, 20, ?_passes(ets_statem:prop_parallel_ets())},
      {timeout, 20, ?_passes(pdict_fsm:prop_pdict())}].
 
+-ifdef(AT_LEAST_17).
+map_in_nextstate3_test_() ->
+	[?_passes(symb_statem_maps:prop_simple()),
+	{timeout, 20, ?_passes(symb_statem_maps:prop_parallel_simple())}].
+-endif.
+
 false_props_test_() ->
     [?_failsWith([[_Same,_Same]],
 		 ?FORALL(L,list(integer()),is_sorted(L,lists:usort(L)))),

--- a/test/symb_statem_maps.erl
+++ b/test/symb_statem_maps.erl
@@ -1,0 +1,83 @@
+%%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
+%%%                     Eirini Arvaniti <eirinibob@gmail.com>
+%%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
+%%%
+%%% This file is part of PropEr.
+%%%
+%%% PropEr is free software: you can redistribute it and/or modify
+%%% it under the terms of the GNU General Public License as published by
+%%% the Free Software Foundation, either version 3 of the License, or
+%%% (at your option) any later version.
+%%%
+%%% PropEr is distributed in the hope that it will be useful,
+%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%%% GNU General Public License for more details.
+%%%
+%%% You should have received a copy of the GNU General Public License
+%%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+
+%%% @copyright 2010-2011 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
+%%% @version {@version}
+%%% @author Eirini Arvaniti
+
+-module(symb_statem_maps).
+
+-include("compile_flags.hrl").
+-ifdef(AT_LEAST_17).
+
+-include_lib("proper/include/proper.hrl").
+
+-export([command/1,
+	initial_state/0,
+	next_state/3,
+	precondition/2,
+	postcondition/3]).
+
+-export([qux/1]).
+
+-record(state, {qux = #{key => []} :: map()}).
+
+initial_state() ->
+	#state{}.
+
+command(_S) ->
+	oneof([{call,?MODULE,qux,[integer()]}]).
+
+precondition(_, _) ->
+	true.
+
+next_state(S = #state{qux=Qux}, V, {call,?MODULE,qux,[_Arg]}) ->
+	Values = maps:get(key, Qux),
+	NewValues = {call,maps,get,[key,V]},
+	NewQux = Qux#{key => [{call,erlang,hd,[NewValues]} | Values]},
+	S#state{qux = NewQux}.
+
+postcondition(S=#state{qux=#{key:=Values}}, {call,?MODULE,qux,[_Arg]}, Res)
+  when is_map(Res) ->
+	lists:all(fun is_integer/1, Values);
+postcondition(_, _, _) ->
+	false.
+
+qux(I) when is_integer(I) ->
+	#{key => lists:duplicate(3, I)}.
+
+prop_simple() ->
+	?FORALL(Cmds, commands(?MODULE),
+		begin
+		{H,S,Res} = run_commands(?MODULE, Cmds),
+		?WHENFAIL(
+		   io:format("H: ~w\nState: ~p\n:Res: ~w\n", [H,S,Res]),
+		   Res =:= ok)
+		end).
+
+prop_parallel_simple() ->
+	?FORALL(Cmds, parallel_commands(?MODULE),
+		begin
+		{S,P,Res} = run_parallel_commands(?MODULE, Cmds),
+		?WHENFAIL(
+		   io:format("Seq: ~w\nParallel: ~p\n:Res: ~w\n", [S,P,Res]),
+		   Res =:= ok)
+		end).
+
+-endif.


### PR DESCRIPTION
Rewrite of #119 & adding a test.

Note: this is not "whole maps support" as #119's top line hinted: only a fix for part 3 of #118.

The test is a copy of symb_statem that reads from a map in a symbolic value and updates the SUT's map state.