### PR TITLE
Implementation of a ?SETUP macro

### DIFF
--- a/include/proper_common.hrl
+++ b/include/proper_common.hrl
@@ -32,7 +32,7 @@
 -define(WHENFAIL(Action,Prop), proper:whenfail(?DELAY(Action),?DELAY(Prop))).
 -define(TRAPEXIT(Prop), proper:trapexit(?DELAY(Prop))).
 -define(TIMEOUT(Limit,Prop), proper:timeout(Limit,?DELAY(Prop))).
--define(SETUP(SetupFun,Prop), proper:setup(SetupFun, Prop)).
+-define(SETUP(SetupFun,Prop), proper:setup(SetupFun,Prop)).
 %% TODO: -define(ALWAYS(Tests,Prop), proper:always(Tests,?DELAY(Prop))).
 %% TODO: -define(SOMETIMES(Tests,Prop), proper:sometimes(Tests,?DELAY(Prop))).
 

--- a/include/proper_common.hrl
+++ b/include/proper_common.hrl
@@ -32,9 +32,9 @@
 -define(WHENFAIL(Action,Prop), proper:whenfail(?DELAY(Action),?DELAY(Prop))).
 -define(TRAPEXIT(Prop), proper:trapexit(?DELAY(Prop))).
 -define(TIMEOUT(Limit,Prop), proper:timeout(Limit,?DELAY(Prop))).
+-define(SETUP(SetupFun,Prop), proper:setup(SetupFun, Prop)).
 %% TODO: -define(ALWAYS(Tests,Prop), proper:always(Tests,?DELAY(Prop))).
 %% TODO: -define(SOMETIMES(Tests,Prop), proper:sometimes(Tests,?DELAY(Prop))).
-
 
 %%------------------------------------------------------------------------------
 %% Generator macros

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -674,9 +674,9 @@ global_state_erase() ->
 setup_test(#opts{setup_funs = Funs}) ->
 	[Fun() || Fun <- Funs].
 
--spec finalize_test([finalize_fun()]) -> ['ok'].
+-spec finalize_test([finalize_fun()]) -> 'ok'.
 finalize_test(Finalizers) ->
-	[ok = Fun() || Fun <- Finalizers].
+	lists:foreach(fun (Fun) -> ok = Fun() end, Finalizers).
 
 %% @private
 -spec spawn_link_migrate(fun(() -> 'ok')) -> pid().
@@ -1045,7 +1045,7 @@ test(RawTest, Opts) ->
     global_state_init(Opts),
 		Finalizers = setup_test(Opts),
     Result = inner_test(RawTest, Opts),
-		_ = finalize_test(Finalizers),
+		ok = finalize_test(Finalizers),
     global_state_erase(),
     Result.
 
@@ -1069,7 +1069,7 @@ retry(Test, CExm, Opts) ->
     RunResult = rerun(Test, false, CExm),
     report_rerun_result(RunResult, Opts),
     ShortResult = get_rerun_result(RunResult),
-		_ = finalize_test(Finalizers),
+		ok = finalize_test(Finalizers),
     global_state_erase(),
     ShortResult.
 
@@ -1100,7 +1100,7 @@ multi_test(Mod, RawTestKind,
 		Error = {error,Reason},
 		{Error, Error}
 	end,
-    _ = finalize_test(Finalizers),
+    ok = finalize_test(Finalizers),
     global_state_erase(),
     case ReturnLong of
 	true  -> LongResult;

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -422,7 +422,7 @@
 		    | numtests_clause()
 		    | fails_clause()
 		    | on_output_clause()
-				| setup_clause().
+		    | setup_clause().
 %% TODO: This should be opaque.
 %% TODO: Should the tags be of the form '$...'?
 %% @type test(). A testable property that has not been wrapped with an
@@ -504,7 +504,7 @@
 	       spec_timeout     = infinity        :: timeout(),
 	       skip_mfas        = []              :: [mfa()],
 	       false_positive_mfas                :: false_positive_mfas(),
-				 setup_funs        = []              :: [setup_fun()]}).
+	       setup_funs       = []              :: [setup_fun()]}).
 -type opts() :: #opts{}.
 -record(ctx, {mode     = new :: 'new' | 'try_shrunk' | 'try_cexm',
 	      bound    = []  :: imm_testcase() | counterexample(),
@@ -1043,7 +1043,7 @@ equals(A, B) ->
 -spec test(raw_test(), opts()) -> result().
 test(RawTest, Opts) ->
     global_state_init(Opts),
-		Finalizers = setup_test(Opts),
+    Finalizers = setup_test(Opts),
     Result = inner_test(RawTest, Opts),
     ok = finalize_test(Finalizers),
     global_state_erase(),
@@ -1065,7 +1065,7 @@ inner_test(RawTest, #opts{numtests = NumTests, long_result = ReturnLong,
 -spec retry(test(), counterexample(), opts()) -> short_result().
 retry(Test, CExm, Opts) ->
     global_state_init(Opts),
-		Finalizers = setup_test(Opts),
+    Finalizers = setup_test(Opts),
     RunResult = rerun(Test, false, CExm),
     report_rerun_result(RunResult, Opts),
     ShortResult = get_rerun_result(RunResult),
@@ -1078,7 +1078,7 @@ multi_test(Mod, RawTestKind,
 	   #opts{long_result = ReturnLong, output_fun = Print,
 		 skip_mfas = SkipMFAs} = Opts) ->
     global_state_init(Opts),
-		Finalizers = setup_test(Opts),
+    Finalizers = setup_test(Opts),
     MaybeMFAs =
 	case RawTestKind of
 	    test -> {ok, [{Mod,Name,0} || {Name,0} <- Mod:module_info(exports),

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -674,7 +674,7 @@ global_state_erase() ->
 setup_test(#opts{setup_funs = Funs}) ->
 	[Fun() || Fun <- Funs].
 
--spec finalize_test([finalize_fun()]) -> 'ok'.
+-spec finalize_test([finalize_fun()]) -> ['ok'].
 finalize_test(Finalizers) ->
 	[ok = Fun() || Fun <- Finalizers].
 
@@ -1045,7 +1045,7 @@ test(RawTest, Opts) ->
     global_state_init(Opts),
 		Finalizers = setup_test(Opts),
     Result = inner_test(RawTest, Opts),
-		finalize_test(Finalizers),
+		_ = finalize_test(Finalizers),
     global_state_erase(),
     Result.
 
@@ -1069,7 +1069,7 @@ retry(Test, CExm, Opts) ->
     RunResult = rerun(Test, false, CExm),
     report_rerun_result(RunResult, Opts),
     ShortResult = get_rerun_result(RunResult),
-		finalize_test(Finalizers),
+		_ = finalize_test(Finalizers),
     global_state_erase(),
     ShortResult.
 
@@ -1100,7 +1100,7 @@ multi_test(Mod, RawTestKind,
 		Error = {error,Reason},
 		{Error, Error}
 	end,
-    finalize_test(Finalizers),
+    _ = finalize_test(Finalizers),
     global_state_erase(),
     case ReturnLong of
 	true  -> LongResult;

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -73,6 +73,11 @@
 %%%   than `<Time_limit>' milliseconds to return. The purpose of this wrapper is
 %%%   to test code that may hang if something goes wrong. `?TIMEOUT' cannot
 %%%   contain any more wrappers.</dd>
+%%% <dt>`?SETUP(<Fun, Prop>)'</dt>
+%%% <dd>Adds a setup function to the property which will be called before the
+%%%   first test. The setup function has to return a finalize function that
+%%%   will be called after the last test. It is possible to use multiple ?SETUP
+%%%   macros on the same property.</dd>
 %%% <dt>`conjunction(<SubProps>)'</dt>
 %%% <dd>See the documentation for {@link conjunction/1}.</dd>
 %%% <dt>`equals(<A>, <B>)'</dt>
@@ -361,7 +366,7 @@
 -export([forall/2, implies/2, whenfail/2, trapexit/1, timeout/2, setup/2]).
 
 -export_type([test/0, outer_test/0, counterexample/0, exception/0,
-	      false_positive_mfas/0]).
+	      false_positive_mfas/0, setup_fun/0, finalize_fun/0]).
 
 -include("proper_internal.hrl").
 

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -366,7 +366,7 @@
 -export([forall/2, implies/2, whenfail/2, trapexit/1, timeout/2, setup/2]).
 
 -export_type([test/0, outer_test/0, counterexample/0, exception/0,
-	      false_positive_mfas/0, setup_fun/0, finalize_fun/0]).
+	      false_positive_mfas/0]).
 
 -include("proper_internal.hrl").
 
@@ -1045,7 +1045,7 @@ test(RawTest, Opts) ->
     global_state_init(Opts),
 		Finalizers = setup_test(Opts),
     Result = inner_test(RawTest, Opts),
-		ok = finalize_test(Finalizers),
+    ok = finalize_test(Finalizers),
     global_state_erase(),
     Result.
 
@@ -1069,7 +1069,7 @@ retry(Test, CExm, Opts) ->
     RunResult = rerun(Test, false, CExm),
     report_rerun_result(RunResult, Opts),
     ShortResult = get_rerun_result(RunResult),
-		ok = finalize_test(Finalizers),
+    ok = finalize_test(Finalizers),
     global_state_erase(),
     ShortResult.
 

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -73,11 +73,11 @@
 %%%   than `<Time_limit>' milliseconds to return. The purpose of this wrapper is
 %%%   to test code that may hang if something goes wrong. `?TIMEOUT' cannot
 %%%   contain any more wrappers.</dd>
-%%% <dt>`?SETUP(<Fun, Prop>)'</dt>
-%%% <dd>Adds a setup function to the property which will be called before the
-%%%   first test. The setup function has to return a finalize function that
-%%%   will be called after the last test. It is possible to use multiple ?SETUP
-%%%   macros on the same property.</dd>
+%%% <dt>`?SETUP(<Fun>, <Prop>)'</dt>
+%%% <dd>Adds a setup `<Fun>'ction to the property which will be called before the
+%%%   first test. This function has to return a finalize function of arity 0,
+%%%   which should return the atom `ok', that will be called after the last test.
+%%%   It is possible to use multiple `?SETUP' macros on the same property.</dd>
 %%% <dt>`conjunction(<SubProps>)'</dt>
 %%% <dd>See the documentation for {@link conjunction/1}.</dd>
 %%% <dt>`equals(<A>, <B>)'</dt>

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -672,11 +672,11 @@ global_state_erase() ->
 
 -spec setup_test(opts()) -> [finalize_fun()].
 setup_test(#opts{setup_funs = Funs}) ->
-	[Fun() || Fun <- Funs].
+    [Fun() || Fun <- Funs].
 
 -spec finalize_test([finalize_fun()]) -> 'ok'.
 finalize_test(Finalizers) ->
-	lists:foreach(fun (Fun) -> ok = Fun() end, Finalizers).
+    lists:foreach(fun (Fun) -> ok = Fun() end, Finalizers).
 
 %% @private
 -spec spawn_link_migrate(fun(() -> 'ok')) -> pid().
@@ -941,7 +941,7 @@ forall(RawType, DTest) ->
 %% @private
 -spec setup(setup_fun(), outer_test()) -> setup_clause().
 setup(Fun, Test) ->
-	{setup, Fun, Test}.
+    {setup, Fun, Test}.
 
 %% @doc Returns a property that is true only if all of the sub-properties
 %% `SubProps' are true. Each sub-property should be tagged with a distinct atom.

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -1040,63 +1040,63 @@ options_test_() ->
 		 [{start_size,12}])].
 
 setup_prop() ->
-  ?SETUP(fun () ->
-           put(setup_token, true),
-           fun () ->
-             erase(setup_token),
-             ok
-           end
-         end,
-         ?FORALL(_, exactly(ok), get(setup_token))).
+    ?SETUP(fun () ->
+		   put(setup_token, true),
+		   fun () ->
+			   erase(setup_token),
+			   ok
+		   end
+	   end,
+	   ?FORALL(_, exactly(ok), get(setup_token))).
 
 failing_setup_prop() ->
-  ?SETUP(fun () ->
-           put(setup_token, true),
-           fun () ->
-             erase(setup_token),
-             ok
-           end
-         end,
-         ?FORALL(_, exactly(ok), not get(setup_token))).
+    ?SETUP(fun () ->
+		   put(setup_token, true),
+		   fun () ->
+			   erase(setup_token),
+			   ok
+		   end
+	   end,
+	   ?FORALL(_, exactly(ok), not get(setup_token))).
 
 double_setup_prop() ->
-  ?SETUP(fun () ->
-           put(setup_token2, true),
-           fun () ->
-             erase(setup_token2),
-             ok
-           end
-         end,
-  ?SETUP(fun () ->
-           put(setup_token, true),
-           fun () ->
-             erase(setup_token),
-             ok
-           end
-         end,
-         ?FORALL(_, exactly(ok), get(setup_token) andalso get(setup_token2)))).
+    ?SETUP(fun () ->
+		   put(setup_token2, true),
+		   fun () ->
+			   erase(setup_token2),
+			   ok
+		   end
+	   end,
+	   ?SETUP(fun () ->
+			  put(setup_token, true),
+			  fun () ->
+				  erase(setup_token),
+				  ok
+			  end
+		  end,
+		  ?FORALL(_, exactly(ok), get(setup_token) andalso get(setup_token2)))).
 
 setup_test_() ->
-  [?_passes(setup_prop(), [10]),
-   ?_assert(proper:quickcheck(setup_prop(), 10)
-            andalso undefined =:= get(setup_token)),
-   ?_fails(failing_setup_prop(), [10]),
-   ?_assert(not proper:quickcheck(failing_setup_prop(), [10, noshrink, quiet])
-            andalso undefined =:= get(setup_token)),
-   ?_assert(proper:check(setup_prop(), [ok], 10)),
-   ?_assert(proper:check(setup_prop(), [ok], 10)
-            andalso undefined =:= get(setup_token)),
-   ?_assert(not proper:check(failing_setup_prop(), [ok], 10)),
-   ?_assert(not proper:check(failing_setup_prop(), [ok], 10)
-            andalso undefined =:= get(setup_token)),
-   ?_passes(double_setup_prop(), [10]),
-   ?_assert(proper:quickcheck(double_setup_prop(), 10)
-            andalso undefined =:= get(setup_token)
-            andalso undefined =:= get(setup_token2)),
-   ?_assert(proper:check(double_setup_prop(), [ok], 10)),
-   ?_assert(true = proper:check(double_setup_prop(), [ok], 10)
-            andalso undefined =:= get(setup_token)
-            andalso undefined =:= get(setup_token2))].
+    [?_passes(setup_prop(), [10]),
+     ?_assert(proper:quickcheck(setup_prop(), 10)
+	      andalso undefined =:= get(setup_token)),
+     ?_fails(failing_setup_prop(), [10]),
+     ?_assert(not proper:quickcheck(failing_setup_prop(), [10, noshrink, quiet])
+	      andalso undefined =:= get(setup_token)),
+     ?_assert(proper:check(setup_prop(), [ok], 10)),
+     ?_assert(proper:check(setup_prop(), [ok], 10)
+	      andalso undefined =:= get(setup_token)),
+     ?_assert(not proper:check(failing_setup_prop(), [ok], 10)),
+     ?_assert(not proper:check(failing_setup_prop(), [ok], 10)
+	      andalso undefined =:= get(setup_token)),
+     ?_passes(double_setup_prop(), [10]),
+     ?_assert(proper:quickcheck(double_setup_prop(), 10)
+	      andalso undefined =:= get(setup_token)
+	      andalso undefined =:= get(setup_token2)),
+     ?_assert(proper:check(double_setup_prop(), [ok], 10)),
+     ?_assert(true = proper:check(double_setup_prop(), [ok], 10)
+	      andalso undefined =:= get(setup_token)
+	      andalso undefined =:= get(setup_token2))].
 
 -ifdef(NO_MODULES_IN_OPAQUES).
 -define(SET,  set).

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -1040,31 +1040,39 @@ options_test_() ->
 		 [{start_size,12}])].
 
 setup_prop() ->
-  ?SETUP(fun () -> put(setup_token, true),
-                  fun () -> erase(setup_token),
-                            ok
-                  end
+  ?SETUP(fun () ->
+           put(setup_token, true),
+           fun () ->
+             erase(setup_token),
+             ok
+           end
          end,
          ?FORALL(_, exactly(ok), get(setup_token))).
 
 failing_setup_prop() ->
-  ?SETUP(fun () -> put(setup_token, true),
-                  fun () -> erase(setup_token),
-                            ok
-                  end
+  ?SETUP(fun () ->
+           put(setup_token, true),
+           fun () ->
+             erase(setup_token),
+             ok
+           end
          end,
          ?FORALL(_, exactly(ok), not get(setup_token))).
 
 double_setup_prop() ->
-  ?SETUP(fun () -> put(setup_token2, true),
-                   fun () -> erase(setup_token2),
-                             ok
-                   end
+  ?SETUP(fun () ->
+           put(setup_token2, true),
+           fun () ->
+             erase(setup_token2),
+             ok
+           end
          end,
-  ?SETUP(fun () -> put(setup_token, true),
-                   fun () -> erase(setup_token),
-                            ok
-                   end
+  ?SETUP(fun () ->
+           put(setup_token, true),
+           fun () ->
+             erase(setup_token),
+             ok
+           end
          end,
          ?FORALL(_, exactly(ok), get(setup_token) andalso get(setup_token2)))).
 


### PR DESCRIPTION
This implements a ?SETUP macro that works as follows:
```erlang
?SETUP(fun () ->       % setup function
           do_some_setting_up(),
           fun () ->   % finalize function
               ok = do_some_finalizing(),
           end
       end,
       ?FORALL( ... ))
```

The setup function is called an is expected to return a finalize function. The setup function is called before the first test to setup a test environment. The finalize function is then called after the last test.

This also fixes #115 
