### PR TITLE
Support for Hex.pm

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,30 @@
+defmodule Proper.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :proper,
+     version: "1.2.0",
+     description: description(),
+     package: package(),
+     deps: deps()]
+  end
+
+  defp deps do
+    [
+      {:ex_doc, "~> 0.14", only: :dev},
+    ]
+  end
+
+  defp description do
+    """
+    QuickCheck-inspired property-based testing tool for Erlang.
+    """
+  end
+
+  defp package do
+     [files: ~w(src include rebar.config configure Makefile COPYING README.md THANKS check_escripts.sh clean_doc.sh clean_temp.sh write_compile_flags mix.exs),
+     maintainers: ["Manolis Papadakis", "Eirini Arvaniti", "Kostis Sagonas"],
+     licenses: ["GPL"],
+     links: %{"GitHub" => "https://github.com/manopapad/proper"}]
+   end
+end

--- a/src/proper.app.src
+++ b/src/proper.app.src
@@ -24,7 +24,7 @@
 
 {application, proper,
  [{description, "A QuickCheck-inspired property-based testing tool for Erlang"},
-  {vsn, "1.2"},
+  {vsn, "1.2.0"},
   {registered, []},
   {applications, [compiler,kernel,stdlib]},
   {env, []}]}.


### PR DESCRIPTION
Related to discussion in https://github.com/manopapad/proper/issues/146 I made a pull request of the `mix.exs` file that I've used to publish proper to [Hex.pm](https://hex.pm/packages/proper). It requires the `src/proper.app.src` to be modified to support semantic versioning that is required by Hex.

The package can be built by running first `make` that will generate some header files and build proper. After this running `mix hex.publish` will publish the package to Hex.