### PR TITLE
search macro improvements (see issue #157)

### DIFF
--- a/include/proper_common.hrl
+++ b/include/proper_common.hrl
@@ -31,8 +31,10 @@
 %%------------------------------------------------------------------------------
 
 -define(FORALL(X,RawType,Prop), proper:forall(RawType,fun(X) -> Prop end)).
--define(EXISTS(X,TMap,Prop), proper:exists(TMap, fun(X) -> Prop end, false)).
--define(NOT_EXISTS(X,TMap,Prop), proper:exists(TMap, fun(X) -> Prop end, true)).
+-define(EXISTS(X,RawType,Prop), proper:exists(RawType, fun(X) -> Prop end, false)).
+-define(NOT_EXISTS(X,RawType,Prop), proper:exists(RawType, fun(X) -> Prop end, true)).
+-define(FORALL_TARGETED(X, RawType, Prop),
+        proper:exists(RawType, fun(X) -> not Prop end, true)).
 -define(IMPLIES(Pre,Prop), proper:implies(Pre,?DELAY(Prop))).
 -define(WHENFAIL(Action,Prop), proper:whenfail(?DELAY(Action),?DELAY(Prop))).
 -define(TRAPEXIT(Prop), proper:trapexit(?DELAY(Prop))).
@@ -66,6 +68,7 @@
 -define(MAXIMIZE(Fitness), proper_target:update_target_uvs(Fitness, inf)).
 -define(MINIMIZE(Fitness), ?MAXIMIZE(-Fitness)).
 -define(USERNF(Type, NF), proper_sa_gen:set_user_nf(Type, NF)).
+-define(USERMATCHER(Type, Matcher), proper_sa_gen:set_matcher(Type, Matcher)).
 
 %%------------------------------------------------------------------------------
 %% Macros for backwards compatibility

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -2,7 +2,7 @@
 %%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>,
 %%%                     Kostis Sagonas <kostis@cs.ntua.gr>,
-%%%                 and Andreas Lï¿½scher <andreas.loscher@it.uu.se>
+%%%                 and Andreas Löscher <andreas.loscher@it.uu.se>
 %%%
 %%% This file is part of PropEr.
 %%%
@@ -19,7 +19,7 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2010-2017 Manolis Papadakis, Eirini Arvaniti, Kostis Sagonas and Andreas Lï¿½scher
+%%% @copyright 2010-2017 Manolis Papadakis, Eirini Arvaniti, Kostis Sagonas and Andreas Löscher
 %%% @version {@version}
 %%% @author Manolis Papadakis
 
@@ -1000,9 +1000,9 @@ setup(Fun, Test) ->
     {setup, Fun, Test}.
 
 %% @private
--spec exists(proper_target:tmap(), dependent_test(), boolean()) -> exists_clause().
-exists(TMap, DTest, Not) ->
-    {exists, TMap, DTest, Not}.
+-spec exists(proper_types:raw_type(), dependent_test(), boolean()) -> exists_clause().
+exists(RawType, DTest, Not) ->
+    {exists, #{gen => RawType}, DTest, Not}.
 
 %% @doc Returns a property that is true only if all of the sub-properties
 %% `SubProps' are true. Each sub-property should be tagged with a distinct atom.
@@ -1295,10 +1295,13 @@ perform_search(Steps, NumSteps, TriesLeft, Target, DTest,
 			false ->
 			    create_pass_result(Ctx, true_prop)
 		    end;
-		#fail{} ->
+		#fail{reason=false_prop} ->
 		    Print(".", []),
 		    grow_size(Opts),
 		    perform_search(Steps + 1, NumSteps, TriesLeft - 1, Target, DTest, Ctx, Opts, Not);
+		#fail{} = FailResult -> %% TODO check that fails in the EXIST macros trigger a bug
+		    Print("!", []),
+		    FailResult#fail{performed = Steps + 1};
 		{error, rejected} ->
 		    Print("x", []),
 		    grow_size(Opts),
@@ -1360,7 +1363,7 @@ run({exists, TMap, Prop, Not}, #ctx{mode = new} = Ctx,
     SR = perform_search(Steps, Target, Prop, Ctx, Opts, Not),
     put('$size', BackupSize),
     Print("]", []),
-    %% proper_target:cleanup_strategy(),
+    %% proper_target:cleanup_strategy(), TODO: why does this not work?
     SR;
 run({exists, TMap, Prop, Not}, #ctx{mode = try_shrunk, bound = []}, Opts) ->
     run({exists, TMap, Prop, Not}, #ctx{mode = new, bound = []}, Opts#opts{output_fun = fun (_, _) -> ok end});

--- a/src/proper_sa_gen.erl
+++ b/src/proper_sa_gen.erl
@@ -654,7 +654,7 @@ get_matcher(Type) ->
 
 -spec match(term(), proper_types:raw_type(), proper_sa:temperature()) -> term().
 match(Base, Type, Temp) ->
-  case proper_type:is_type(Type) of
+  case proper_types:is_type(Type) of
     true ->
       Matcher = get_matcher(Type),
       Matcher(Base, Type, Temp);

--- a/src/proper_sa_gen.erl
+++ b/src/proper_sa_gen.erl
@@ -26,7 +26,11 @@
 -module(proper_sa_gen).
 
 -export([from_proper_generator/1, set_temperature_scaling/1, update_caches/1, init/0, cleanup/0,
-         set_user_nf/2]).
+         set_user_nf/2, set_matcher/2]).
+
+-export([match/3, structural_match/3]).
+
+-export_type([matcher/0]).
 
 -include("proper_internal.hrl").
 
@@ -56,6 +60,8 @@
 
 -define(TEMP(T), calculate_temperature(T)).
 -define(SLTEMP(T), adjust_temperature(T)).
+
+-type matcher() :: fun((term(), proper_types:type(), proper_sa:temperature()) -> term()).
 
 -spec update_caches('accept' | 'reject') -> 'ok'.
 update_caches(accept) ->
@@ -115,6 +121,10 @@ init_pd(Key, Value) ->
 -spec set_user_nf(proper_types:type(), proper_sa:nf()) -> proper_types:type().
 set_user_nf(Type, NF) ->
   proper_types:add_prop(user_nf, NF, Type).
+
+-spec set_matcher(proper_types:type(), matcher()) -> proper_types:type().
+set_matcher(Type, Matcher) ->
+  proper_types:add_prop(matcher, Matcher, Type).
 
 get_depth() ->
   DS = get(proper_sa_gen_depth_cache),
@@ -620,6 +630,7 @@ del_cache_let(Type, Combined) ->
 let_gen_sa(Type) ->
   {ok, Combine} = proper_types:find_prop(combine, Type),
   {ok, PartsType} = proper_types:find_prop(parts_type, Type),
+  Matcher = get_matcher(Type),
   PartsGen = replace_generators(PartsType),
   fun (Base, Temp) ->
       LetOuter = case get_cached_let(Type, Base) of
@@ -630,12 +641,27 @@ let_gen_sa(Type) ->
                      sample_from_type(PartsType, ?SLTEMP(Temp))
                  end,
       RawCombined = Combine(LetOuter),
-      NewValue = match_cook(Base, RawCombined, Temp),
+      NewValue = Matcher(Base, RawCombined, Temp),
       set_cache_let(Type, NewValue, LetOuter),
       NewValue
   end.
 
-match_cook(Base, Type = {'$type', _}, Temp) ->
+get_matcher(Type) ->
+  case proper_types:find_prop(matcher, Type) of
+    {ok, MatchFun} -> MatchFun;
+    error -> fun structural_match/3
+  end.
+
+-spec match(term(), proper_types:type(), proper_sa:temperature()) -> term().
+match(Base, Type = {'$type', _}, Temp) ->
+  Matcher = get_matcher(Type),
+  Matcher(Base, Type, Temp);
+match(Base, Type, Temp) ->
+  %% if we only have values left, we use structural matching
+  structural_match(Base, Type, Temp).
+
+-spec structural_match(term(), proper_types:type(), proper_sa:temperature()) -> term().
+structural_match(Base, Type = {'$type', _}, Temp) ->
   case Base of
     no_matching ->
       sample_from_type(Type, ?TEMP(Temp));
@@ -644,7 +670,7 @@ match_cook(Base, Type = {'$type', _}, Temp) ->
       BaseNormalized = Gen(Base, null),
       Gen(BaseNormalized, ?SLTEMP(Temp))
   end;
-match_cook(Base, RawType, Temp) ->
+structural_match(Base, RawType, Temp) ->
   if
     is_tuple(RawType) ->
       case is_set(RawType) orelse is_dict(RawType) of
@@ -654,9 +680,9 @@ match_cook(Base, RawType, Temp) ->
         _ ->
           MC = case is_tuple(Base) of
                  true ->
-                   match_cook(tuple_to_list(Base), tuple_to_list(RawType), Temp);
+                   structural_match(tuple_to_list(Base), tuple_to_list(RawType), Temp);
                  false ->
-                   match_cook(no_matching, tuple_to_list(RawType), Temp)
+                   structural_match(no_matching, tuple_to_list(RawType), Temp)
                end,
           list_to_tuple(MC)
       end;
@@ -680,7 +706,7 @@ no_matching_list_zip([H|T]) ->[{no_matching, H} | no_matching_list_zip(T)];
 no_matching_list_zip(ImproperTail) -> {no_matching, ImproperTail}.
 
 per_element_match_cook(ZippedBasesWithTypes, Temp) ->
-  safe_map(fun ({B, RT}) -> match_cook(B, RT, Temp) end, ZippedBasesWithTypes).
+  safe_map(fun ({B, RT}) -> structural_match(B, RT, Temp) end, ZippedBasesWithTypes).
 
 safe_map(_Fun, []) -> [];
 safe_map(Fun, [H|T]) ->
@@ -814,7 +840,9 @@ user_defined_gen_sa(Type) ->
   NF = proper_types:get_prop(user_nf, Type),
   fun (Base, T) ->
       NewRaw = NF(Base, T),
-      match_cook(Base, NewRaw, T)
+      {ok, Generated} = proper_gen:clean_instance(proper_gen:safe_generate(NewRaw)),
+      %% match(Base, NewRaw, T)
+      Generated
   end.
 
 %% utility

--- a/src/proper_sa_gen.erl
+++ b/src/proper_sa_gen.erl
@@ -648,7 +648,7 @@ let_gen_sa(Type) ->
 
 get_matcher(Type) ->
   case proper_types:find_prop(matcher, Type) of
-    {ok, MatchFun} -> MatchFun;
+    {ok, MatchFun} -> fun (B,I,T) -> MatchFun(B, I, ?TEMP(T)) end;
     error -> fun structural_match/3
   end.
 

--- a/src/proper_statem.erl
+++ b/src/proper_statem.erl
@@ -218,7 +218,7 @@
 
 -module(proper_statem).
 
--export([commands/1, commands/2, commands/4, parallel_commands/1, parallel_commands/2,
+-export([commands/1, commands/2, parallel_commands/1, parallel_commands/2,
 	 more_commands/2]).
 -export([run_commands/2, run_commands/3, run_parallel_commands/2,
 	 run_parallel_commands/3]).

--- a/src/proper_statem.erl
+++ b/src/proper_statem.erl
@@ -218,7 +218,7 @@
 
 -module(proper_statem).
 
--export([commands/1, commands/2, parallel_commands/1, parallel_commands/2,
+-export([commands/1, commands/2, commands/4, parallel_commands/1, parallel_commands/2,
 	 more_commands/2]).
 -export([run_commands/2, run_commands/3, run_parallel_commands/2,
 	 run_parallel_commands/3]).
@@ -328,6 +328,7 @@ commands(Mod, InitialState) ->
 	    [{init,InitialState}|CmdTail]),
        is_valid(Mod, InitialState, Cmds, [])).
 
+%% @private
 -spec commands(size(), mod_name(), symbolic_state(), pos_integer()) ->
          proper_types:type().
 commands(Size, Mod, State, Count) ->

--- a/test/exists_tests.erl
+++ b/test/exists_tests.erl
@@ -327,13 +327,13 @@ matching_graph() ->
 -spec graph_match1_test_() -> 'ok'.
 graph_match1_test_() ->
   Opts = ?PROPER_OPTIONS,
-  ?timeout(1000, ?_assert(proper:quickcheck(prop_graph_match_corr(), Opts))).
+  ?timeout(60, ?_assert(proper:quickcheck(prop_graph_match_corr(), Opts))).
 
 
 -spec graph_match2_test_() -> 'ok'.
 graph_match2_test_() ->
   Opts = ?PROPER_OPTIONS,
-  ?timeout(1000, ?_assert(proper:quickcheck(prop_graph_match_perf(), Opts))).
+  ?timeout(60, ?_assert(proper:quickcheck(prop_graph_match_perf(), Opts))).
 
 prop_graph_match_perf() ->
   ?EXISTS({V, E}, matching_graph(),

--- a/test/exists_tests.erl
+++ b/test/exists_tests.erl
@@ -414,7 +414,7 @@ prop_shrink4() ->
               end).
 
 matching_type() ->
-        ?LET(I, integer(), I).
+  ?LET(I, integer(), I).
 
 prop_match() ->
   ?FORALL_TARGETED(I, ?USERMATCHER(matching_type(), fun proper_sa_gen:match/3),

--- a/test/exists_tests.erl
+++ b/test/exists_tests.erl
@@ -407,3 +407,18 @@ prop_shrink4() ->
                 ?MINIMIZE(I),
                 I < 10
               end).
+
+matching_type() ->
+        ?LET(I, integer(), I).
+
+prop_match() ->
+  ?FORALL_TARGETED(I, ?USERMATCHER(matching_type(), fun proper_sa_gen:match/3),
+                   begin
+                     ?MAXIMIZE(I),
+                     I < 10
+                   end).
+
+-spec match_test() -> 'ok'.
+match_test() ->
+  false = proper:quickcheck(prop_match(), ?PROPER_OPTIONS_SHRINKING),
+  ok.

--- a/test/exists_tests.erl
+++ b/test/exists_tests.erl
@@ -43,10 +43,10 @@ prop_strategy() ->
 
 prop_forall_sa() ->
   ?FORALL_SA(X, ?TARGET(proper_sa:integer()),
-          begin
-            ?MAXIMIZE(X),
-            X < 10
-          end).
+             begin
+               ?MAXIMIZE(X),
+               X < 10
+             end).
 
 strategy_test() ->
   false = proper:quickcheck(prop_strategy(), ?PROPER_OPTIONS_SHRINKING),
@@ -61,24 +61,36 @@ forall_sa_test() ->
 %% Macros Test
 prop_exists() ->
   ?FORALL(X, integer(),
-          ?EXISTS(I, proper_sa:integer(),
+          ?EXISTS(I, integer(),
                   begin
                     ?MAXIMIZE(I),
                     I > X
                   end)).
 
 prop_not_exists() ->
-  ?NOT_EXISTS(I, proper_sa:integer(),
+  ?NOT_EXISTS(I, integer(),
               begin
                 ?MAXIMIZE(I),
                 I >= 10
               end).
+
+prop_forall_targeted() ->
+  ?FORALL_TARGETED(I, integer(),
+                   begin
+                     ?MAXIMIZE(I),
+                     I < 10
+                   end).
 
 exists_test() ->
   ?assert(proper:quickcheck(prop_exists(), ?PROPER_OPTIONS)).
 
 not_exists_test() ->
   false = proper:quickcheck(prop_not_exists(), ?PROPER_OPTIONS_SHRINKING),
+  [10] = proper:counterexample(),
+  ok.
+
+forall_targeted_test() ->
+  false = proper:quickcheck(prop_forall_targeted(), ?PROPER_OPTIONS_SHRINKING),
   [10] = proper:counterexample(),
   ok.
 
@@ -130,7 +142,7 @@ biglist_test() ->
 
 prop_big_list() ->
   Gen = proper_types:list(atom),
-  ?NOT_EXISTS(List, #{gen =>Gen},
+  ?NOT_EXISTS(List, Gen,
               begin
                 L = length(List),
                 ?MINIMIZE(abs(L - 50)),
@@ -143,7 +155,7 @@ let_test() ->
   ?assert(proper:quickcheck(prop_let(), ?PROPER_OPTIONS)).
 
 prop_let() ->
-  ?NOT_EXISTS(V, #{gen => even_int()},
+  ?NOT_EXISTS(V, even_int(),
               begin
                 ?MINIMIZE(V),
                 V rem 2 =/= 0
@@ -158,7 +170,7 @@ suchthat_test() ->
   ?assert(proper:quickcheck(prop_suchthat(), ?PROPER_OPTIONS)).
 
 prop_suchthat() ->
-  ?NOT_EXISTS(V, #{gen => suchthat_gen()},
+  ?NOT_EXISTS(V, suchthat_gen(),
               begin
                 ?MAXIMIZE(V),
                 V rem 2 =/= 0
@@ -174,7 +186,7 @@ union_test() ->
 
 prop_union() ->
   L = [a, b, c],
-  ?NOT_EXISTS(X, #{gen => proper_types:union(L)}, not lists:member(X, L)).
+  ?NOT_EXISTS(X, proper_types:union(L), not lists:member(X, L)).
 
 -spec weighted_union_test() -> 'ok'.
 weighted_union_test() ->
@@ -183,7 +195,7 @@ weighted_union_test() ->
 
 prop_weighted_union() ->
   Gen = proper_types:weighted_union([{1, a}, {2, b}, {3, c}]),
-  ?NOT_EXISTS(X, #{gen => Gen}, not lists:member(X, [a, b, c])).
+  ?NOT_EXISTS(X, Gen, not lists:member(X, [a, b, c])).
 
 -spec tuple_test() -> 'ok'.
 tuple_test() ->
@@ -191,7 +203,7 @@ tuple_test() ->
   ?assert(proper:quickcheck(prop_tuple(), ?PROPER_OPTIONS)).
 
 prop_tuple() ->
-  ?NOT_EXISTS({L, R}, #{gen => tuple_type_res()}, L =< R).
+  ?NOT_EXISTS({L, R}, tuple_type_res(), L =< R).
 
 tuple_type_res() ->
   ?SUCHTHAT({V1, V2}, tuple_type(), V1 > V2).
@@ -206,7 +218,7 @@ let_union_test() ->
 
 prop_union_let() ->
   C = lists:seq(0,1),
-  ?NOT_EXISTS(_E, #{gen => union_let_type(C)}, false).
+  ?NOT_EXISTS(_E, union_let_type(C), false).
 
 union_let_type(C) ->
   ?LET(E, union(C), E).
@@ -218,7 +230,7 @@ lazy_test() ->
 
 prop_lazy() ->
   Gen = ?LAZY(?LET(I, integer(), I * 2)),
-  ?NOT_EXISTS(I, #{gen => Gen}, I rem 2 =/= 0).
+  ?NOT_EXISTS(I, Gen, I rem 2 =/= 0).
 
 -spec sized_test() -> 'ok'.
 sized_test() ->
@@ -228,7 +240,7 @@ sized_test() ->
   ?assert(42 =< length(C)).
 
 prop_sized() ->
-  ?NOT_EXISTS(L, #{gen => sized_type()},
+  ?NOT_EXISTS(L, sized_type(),
               begin
                 ?MAXIMIZE(lists:sum(L)),
                 length(L) >= 42
@@ -243,14 +255,14 @@ edge_test() ->
 
 prop_edge() ->
   Gen = simple_edge([1,2,3,4,5,6,7,8,9]),
-  ?NOT_EXISTS({L, R}, #{gen => Gen}, L =< R).
+  ?NOT_EXISTS({L, R}, Gen, L =< R).
 
 -spec graph_test_() -> 'ok'.
 graph_test_() ->
   ?timeout(10, ?_assert(proper:quickcheck(prop_graph(), ?PROPER_OPTIONS))).
 
 prop_graph() ->
-  ?NOT_EXISTS(_, #{gen => simple_graph()}, false).
+  ?NOT_EXISTS(_, simple_graph(), false).
 
 %% simple generator for a graph
 simple_graph() ->
@@ -276,7 +288,7 @@ il_type() ->
   ?LET(I, integer(), [I|42]).
 
 prop_il() ->
-  ?NOT_EXISTS(_L, #{gen => il_type()}, false).
+  ?NOT_EXISTS(_L, il_type(), false).
 
 -spec improper_list_test() -> 'ok'.
 improper_list_test() ->
@@ -285,7 +297,7 @@ improper_list_test() ->
   ?assert(proper:quickcheck(prop_il(), ?PROPER_OPTIONS)).
 
 prop_reset() ->
-  ?NOT_EXISTS(I, stepint(),
+  ?NOT_EXISTS(I, ?USERNF(exactly(0), fun (Base, _) -> Base + 1 end),
               begin
                 ?MAXIMIZE(I),
                 case I < 10 of
@@ -296,10 +308,6 @@ prop_reset() ->
                 %% and then 0 in the next run
                 I > 10
               end).
-
-stepint() ->
-  #{first => 0,
-    next => fun (Base, _) -> Base + 1 end}.
 
 reset_test() ->
   ?assert(proper:quickcheck(prop_reset(), ?PROPER_OPTIONS)).
@@ -320,10 +328,10 @@ matching_graph() ->
 graph_match_test_() ->
   Opts = ?PROPER_OPTIONS,
   ?timeout(100, [?_assert(proper:quickcheck(prop_graph_match_corr(), Opts)),
-		 ?_assert(proper:quickcheck(prop_graph_match_perf(), Opts))]).
+                 ?_assert(proper:quickcheck(prop_graph_match_perf(), Opts))]).
 
 prop_graph_match_perf() ->
-  ?EXISTS({V, E}, #{gen => matching_graph()},
+  ?EXISTS({V, E}, matching_graph(),
           begin
             UV = length(V) - length(E),
             ?MAXIMIZE(UV),
@@ -332,7 +340,7 @@ prop_graph_match_perf() ->
 
 prop_graph_match_corr() ->
   ?NOT_EXISTS({V, E},
-              #{gen => matching_graph()},
+              matching_graph(),
               begin
                 UV = length(V) - length(E),
                 ?MAXIMIZE(UV),
@@ -351,7 +359,7 @@ whenfail_test() ->
   ?assert(get(test_token)).
 
 prop_whenfail() ->
-  ?NOT_EXISTS(_, #{gen => integer()},
+  ?NOT_EXISTS(_, integer(),
               ?WHENFAIL(put(test_token, true), true)).
 
 -spec shrink1_test() -> 'ok'.
@@ -361,7 +369,7 @@ shrink1_test() ->
 
 prop_shrink1() ->
   ?FORALL(I, integer(1000, 1100),
-          ?EXISTS(J, #{gen => integer(1000, 1050)},
+          ?EXISTS(J, integer(1000, 1050),
                   begin
                     ?MAXIMIZE(J),
                     J > I
@@ -374,7 +382,7 @@ shrink2_test() ->
 
 prop_shrink2() ->
   ?FORALL(I, integer(0, 100),
-          ?NOT_EXISTS(J, #{gen => integer(-50, 50)},
+          ?NOT_EXISTS(J, integer(-50, 50),
                       begin
                         ?MAXIMIZE(J),
                         J > I
@@ -386,7 +394,7 @@ shrink3_test() ->
   ?assertMatch(undefined, proper:counterexample()).
 
 prop_shrink3() ->
-  ?EXISTS(_, #{gen => integer()}, false).
+  ?EXISTS(_, integer(), false).
 
 -spec shrink4_test() -> 'ok'.
 shrink4_test() ->
@@ -394,7 +402,7 @@ shrink4_test() ->
   ?assertMatch([0], proper:counterexample()).
 
 prop_shrink4() ->
-  ?NOT_EXISTS(I, #{gen => integer(0, 20)},
+  ?NOT_EXISTS(I, integer(0, 20),
               begin
                 ?MINIMIZE(I),
                 I < 10


### PR DESCRIPTION
`?EXIST` and `?NOT_EXIST` do not require the `#{gen=>...}` thingy anymore and there is a `?FORALL_TARGETED` that works like the exists and is not specialized on a search strategy (which should be specified in the proper options)
