### PR TITLE
Code cleanup (latin1 -> utf8)

### DIFF
--- a/check_escripts.sh
+++ b/check_escripts.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# -*- coding: utf-8 -*-
+# --------------------------------------------------------------------
 # Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 #                     Eirini Arvaniti <eirinibob@gmail.com>
 #                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/clean_doc.sh
+++ b/clean_doc.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# -*- coding: utf-8 -*-
+# --------------------------------------------------------------------
 # Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 #                     Eirini Arvaniti <eirinibob@gmail.com>
 #                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/clean_temp.sh
+++ b/clean_temp.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# -*- coding: utf-8 -*-
+# --------------------------------------------------------------------
 # Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 #                     Eirini Arvaniti <eirinibob@gmail.com>
 #                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/configure
+++ b/configure
@@ -1,4 +1,6 @@
 #! /bin/sh
+
+# -*- coding: utf-8 -*-
 # --------------------------------------------------------------------
 # Copyright 2010-2016 Manolis Papadakis <manopapad@gmail.com>,
 #                     Eirini Arvaniti <eirinibob@gmail.com>

--- a/examples/b64.erl
+++ b/examples/b64.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/examples/elevator_fsm.erl
+++ b/examples/elevator_fsm.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/examples/ets_statem.erl
+++ b/examples/ets_statem.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2016 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/examples/level.erl
+++ b/examples/level.erl
@@ -1,3 +1,28 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
+%%% Copyright (c) 2017, Andreas Löscher <andreas.loscher@it.uu.se>
+%%%                and  Kostis Sagonas <kostis@it.uu.se>
+%%%
+%%% This file is part of PropEr.
+%%%
+%%% PropEr is free software: you can redistribute it and/or modify
+%%% it under the terms of the GNU General Public License as published by
+%%% the Free Software Foundation, either version 3 of the License, or
+%%% (at your option) any later version.
+%%%
+%%% PropEr is distributed in the hope that it will be useful,
+%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%%% GNU General Public License for more details.
+%%%
+%%% You should have received a copy of the GNU General Public License
+%%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+
+%%% @copyright 2017 Andreas Löscher and Kostis Sagonas
+%%% @version {@version}
+%%% @author Andreas Löscher
+
 -module(level).
 -export([level0/0, level1/0, level2/0, build_level/1]).
 -export([prop_exit/1, prop_exit_targeted/1]).

--- a/examples/magic.erl
+++ b/examples/magic.erl
@@ -1,3 +1,27 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
+%%% Copyright (c) 2017, Andreas Löscher <andreas.loscher@it.uu.se>
+%%%
+%%% This file is part of PropEr.
+%%%
+%%% PropEr is free software: you can redistribute it and/or modify
+%%% it under the terms of the GNU General Public License as published by
+%%% the Free Software Foundation, either version 3 of the License, or
+%%% (at your option) any later version.
+%%%
+%%% PropEr is distributed in the hope that it will be useful,
+%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%%% GNU General Public License for more details.
+%%%
+%%% You should have received a copy of the GNU General Public License
+%%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+
+%%% @copyright 2017 Andreas Löscher
+%%% @version {@version}
+%%% @author Andreas Löscher
+
 -module(magic).
 -export([spells/0, cast_spell/2, cast_spells/2]).
 -export([run_random/1, run_generated/1, run_handwritten/1, count_spells/1]).

--- a/examples/mm.erl
+++ b/examples/mm.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/examples/pdict_statem.erl
+++ b/examples/pdict_statem.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/examples/stack.erl
+++ b/examples/stack.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/include/proper.hrl
+++ b/include/proper.hrl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/include/proper_common.hrl
+++ b/include/proper_common.hrl
@@ -1,9 +1,10 @@
-%%% coding: latin-1
+%%% -*- coding: utf-8 -*-
 %%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>,
 %%%                     Kostis Sagonas <kostis@cs.ntua.gr>,
-%%%                 and Andreas Löscher <andreas.loscher@it.uu.se>
+%%%                 and Andreas LÃ¶scher <andreas.loscher@it.uu.se>
 %%%
 %%% This file is part of PropEr.
 %%%
@@ -20,7 +21,7 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2010-2017 Manolis Papadakis, Eirini Arvaniti, Kostis Sagonas and Andreas Löscher
+%%% @copyright 2010-2017 Manolis Papadakis, Eirini Arvaniti, Kostis Sagonas and Andreas LÃ¶scher
 %%% @version {@version}
 %%% @author Manolis Papadakis
 %%% @doc Common parts of user and internal header files

--- a/include/proper_common.hrl
+++ b/include/proper_common.hrl
@@ -68,8 +68,8 @@
 
 -define(MAXIMIZE(Fitness), proper_target:update_target_uvs(Fitness, inf)).
 -define(MINIMIZE(Fitness), ?MAXIMIZE(-Fitness)).
--define(USERNF(Type, NF), proper_sa_gen:set_user_nf(Type, NF)).
--define(USERMATCHER(Type, Matcher), proper_sa_gen:set_matcher(Type, Matcher)).
+-define(USERNF(Type, NF), proper_gen_next:set_user_nf(Type, NF)).
+-define(USERMATCHER(Type, Matcher), proper_gen_next:set_matcher(Type, Matcher)).
 
 %%------------------------------------------------------------------------------
 %% Macros for backwards compatibility

--- a/include/proper_internal.hrl
+++ b/include/proper_internal.hrl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/include/proper_param_adts.hrl
+++ b/include/proper_param_adts.hrl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2013 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/make_doc
+++ b/make_doc
@@ -1,5 +1,8 @@
 #!/usr/bin/env escript
 
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/make_doc
+++ b/make_doc
@@ -113,7 +113,7 @@ process(Filename) ->
     Comments = erl_comment_scan:file(Filename),
     {NewForms,NewComments} = process_forms(Forms, Comments),
     Code = pretty_print(NewForms, NewComments),
-    {ok,IODev} = file:open(Filename, [write]),
+    {ok,IODev} = file:open(Filename, [write, {encoding, utf8}]),
     ok = io:put_chars(IODev, Code),
     ok = file:close(IODev),
     ok.

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,7 @@
 %%% -*- Erlang -*-
-%%%---------------------------------------------------------------------
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2016 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/src/proper.app.src
+++ b/src/proper.app.src
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2013 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -1,7 +1,7 @@
 %%% -*- coding: utf-8 -*-
 %%% -*- erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
+%%% Copyright 2010-2018 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>,
 %%%                     Kostis Sagonas <kostis@cs.ntua.gr>,
 %%%                 and Andreas Löscher <andreas.loscher@it.uu.se>
@@ -21,7 +21,7 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2010-2017 Manolis Papadakis, Eirini Arvaniti, Kostis Sagonas and Andreas Löscher
+%%% @copyright 2010-2018 Manolis Papadakis, Eirini Arvaniti, Kostis Sagonas and Andreas Löscher
 %%% @version {@version}
 %%% @author Manolis Papadakis
 
@@ -724,9 +724,9 @@ setup_test(#opts{output_fun = OutputFun,
 		  max_size => MaxSize,
 		  output_fun => OutputFun},
     [case erlang:fun_info(Fun, arity) of
-			{arity, 0} -> Fun();
-			{arity, 1} -> Fun(SetupOpts)
-		end || Fun <- Funs].
+	{arity, 0} -> Fun();
+	{arity, 1} -> Fun(SetupOpts)
+     end || Fun <- Funs].
 
 -spec finalize_test([finalize_fun()]) -> 'ok'.
 finalize_test(Finalizers) ->
@@ -1411,8 +1411,7 @@ run({forall, RawType, Prop}, #ctx{mode = try_shrunk,
     case proper_types:safe_is_instance(ImmInstance, RawType) of
 	true ->
 	    Instance = proper_gen:clean_instance(ImmInstance),
-	    Result = force(Instance, Prop, Ctx#ctx{bound = Rest}, Opts),
-    Result;
+	    force(Instance, Prop, Ctx#ctx{bound = Rest}, Opts);
 	false ->
 	    %% TODO: could try to fix the instances here
 	    {error, wrong_type};

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -1,8 +1,10 @@
-%%% coding: latin-1
-%%% Copyright 2010-2018 Manolis Papadakis <manopapad@gmail.com>,
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
+%%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>,
 %%%                     Kostis Sagonas <kostis@cs.ntua.gr>,
-%%%                 and Andreas Löscher <andreas.loscher@it.uu.se>
+%%%                 and Andreas LÃ¶scher <andreas.loscher@it.uu.se>
 %%%
 %%% This file is part of PropEr.
 %%%
@@ -19,7 +21,7 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2010-2018 Manolis Papadakis, Eirini Arvaniti, Kostis Sagonas and Andreas Löscher
+%%% @copyright 2010-2017 Manolis Papadakis, Eirini Arvaniti, Kostis Sagonas and Andreas LÃ¶scher
 %%% @version {@version}
 %%% @author Manolis Papadakis
 
@@ -722,9 +724,9 @@ setup_test(#opts{output_fun = OutputFun,
 		  max_size => MaxSize,
 		  output_fun => OutputFun},
     [case erlang:fun_info(Fun, arity) of
-	 {arity, 0} -> Fun();
-	 {arity, 1} -> Fun(SetupOpts)
-     end || Fun <- Funs].
+			{arity, 0} -> Fun();
+			{arity, 1} -> Fun(SetupOpts)
+		end || Fun <- Funs].
 
 -spec finalize_test([finalize_fun()]) -> 'ok'.
 finalize_test(Finalizers) ->
@@ -1409,7 +1411,8 @@ run({forall, RawType, Prop}, #ctx{mode = try_shrunk,
     case proper_types:safe_is_instance(ImmInstance, RawType) of
 	true ->
 	    Instance = proper_gen:clean_instance(ImmInstance),
-	    force(Instance, Prop, Ctx#ctx{bound = Rest}, Opts);
+	    Result = force(Instance, Prop, Ctx#ctx{bound = Rest}, Opts),
+    Result;
 	false ->
 	    %% TODO: could try to fix the instances here
 	    {error, wrong_type};

--- a/src/proper_arith.erl
+++ b/src/proper_arith.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2016 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/src/proper_array.erl
+++ b/src/proper_array.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/src/proper_dict.erl
+++ b/src/proper_dict.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/src/proper_fsm.erl
+++ b/src/proper_fsm.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2016 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/src/proper_gb_sets.erl
+++ b/src/proper_gb_sets.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/src/proper_gb_trees.erl
+++ b/src/proper_gb_trees.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/src/proper_gen.erl
+++ b/src/proper_gen.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/src/proper_gen_next.erl
+++ b/src/proper_gen_next.erl
@@ -1,8 +1,8 @@
 %%% -*- coding: utf-8 -*-
 %%% -*- erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright (c) 2017, Andreas Löscher <andreas.loscher@it.uu.se>
-%%%                and  Kostis Sagonas <kostis@it.uu.se>
+%%% Copyright (c) 2017-2018, Andreas Löscher <andreas.loscher@it.uu.se>
+%%%                     and  Kostis Sagonas <kostis@it.uu.se>
 %%%
 %%% This file is part of PropEr.
 %%%
@@ -19,7 +19,7 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2017 Andreas Löscher and Kostis Sagonas
+%%% @copyright 2017-2018 Andreas Löscher and Kostis Sagonas
 %%% @version {@version}
 %%% @author Andreas Löscher
 
@@ -325,11 +325,10 @@ is_list_type(Type) ->
 list_choice(empty, Temp) ->
   C = ?RANDOM_MOD:uniform(),
   C_Add = 0.5 * Temp,
-  Choice = if
-             C < C_Add -> add;
-             true      -> nothing
-           end,
-  Choice;
+  if
+    C < C_Add -> add;
+    true      -> nothing
+  end;
 list_choice({list, GrowthCoefficient}, Temp) ->
   C = ?RANDOM_MOD:uniform(),
   AddCoefficient = 0.3 * GrowthCoefficient,
@@ -337,21 +336,19 @@ list_choice({list, GrowthCoefficient}, Temp) ->
   C_Add =          AddCoefficient * Temp,
   C_Del = C_Add + (DelCoefficient * Temp),
   C_Mod = C_Del + (0.15 * Temp),
-  Choice = if
-             C < C_Add -> add;
-             C < C_Del -> del;
-             C < C_Mod -> modify;
-             true      -> nothing
-           end,
-  Choice;
+  if
+    C < C_Add -> add;
+    C < C_Del -> del;
+    C < C_Mod -> modify;
+    true      -> nothing
+  end;
 list_choice(vector, Temp) ->
   C = ?RANDOM_MOD:uniform(),
   C_Mod = 0.5 * Temp,
-  Choice = if
-             C < C_Mod -> modify;
-             true      -> nothing
-           end,
-  Choice;
+  if
+    C < C_Mod -> modify;
+    true      -> nothing
+  end;
 list_choice(tuple, Temp) ->
   list_choice(vector, Temp).
 

--- a/src/proper_orddict.erl
+++ b/src/proper_orddict.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/src/proper_ordsets.erl
+++ b/src/proper_ordsets.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/src/proper_prop_remover.erl
+++ b/src/proper_prop_remover.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2013 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/src/proper_queue.erl
+++ b/src/proper_queue.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/src/proper_sets.erl
+++ b/src/proper_sets.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/src/proper_shrink.erl
+++ b/src/proper_shrink.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2013 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/src/proper_statem.erl
+++ b/src/proper_statem.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2016 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/src/proper_symb.erl
+++ b/src/proper_symb.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/src/proper_target.erl
+++ b/src/proper_target.erl
@@ -1,7 +1,7 @@
-%%% coding: latin-1
+%%% -*- coding: utf-8 -*-
 %%% -*- erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright (c) 2017, Andreas L�scher <andreas.loscher@it.uu.se>
+%%% Copyright (c) 2017, Andreas Löscher <andreas.loscher@it.uu.se>
 %%%                and  Konstantinos Sagonas <kostis@it.uu.se>
 %%%
 %%% This file is part of PropEr.
@@ -19,9 +19,9 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2017 Andreas L�scher and Kostis Sagonas
+%%% @copyright 2017 Andreas Löscher and Kostis Sagonas
 %%% @version {@version}
-%%% @author Andreas L�scher
+%%% @author Andreas Löscher
 
 %%% @doc This module defines the top-level behaviour for targeted
 %%% property-based testing (TPBT). Using TPBT the input generation

--- a/src/proper_transformer.erl
+++ b/src/proper_transformer.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/src/proper_types.erl
+++ b/src/proper_types.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
@@ -280,7 +283,7 @@
     | {'parameters', [{atom(),value()}]}
     | {'env', term()}
     | {'subenv', term()}
-    | {'user_nf', proper_sa:nf()}.
+    | {'user_nf', proper_gen_next:nf()}.
 
 
 %%------------------------------------------------------------------------------

--- a/src/proper_typeserver.erl
+++ b/src/proper_typeserver.erl
@@ -1,4 +1,7 @@
-%%% Copyright 2010-2018 Manolis Papadakis <manopapad@gmail.com>,
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
+%%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
 %%%
@@ -17,7 +20,7 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2010-2018 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
+%%% @copyright 2010-2017 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}
 %%% @author Manolis Papadakis
 
@@ -248,9 +251,8 @@
 -type rec_arg() :: {boolean() | {'list',boolean(),rec_fun()},full_type_ref()}.
 -type rec_args() :: [rec_arg()].
 -type ret_type() :: {'simple',fin_type()} | {'rec',rec_fun(),rec_args()}.
--type rec_arg_lens() :: [arity(),...].
--type rec_funs()     :: [rec_fun(),...].
--type rec_fun_info() :: {pos_integer(),pos_integer(),rec_arg_lens(),rec_funs()}.
+-type rec_fun_info() :: {pos_integer(),pos_integer(),[arity(),...],
+			 [rec_fun(),...]}.
 
 -type imm_type_ref() :: {type_name(),arity()}.
 -type hard_adt_repr() :: {abs_type(),[var_name()]} | 'already_declared'.
@@ -2307,11 +2309,11 @@ soft_clean_rec_args_tr([Arg | Rest], Acc, RecFunInfo, ToList, FoundListInst,
     soft_clean_rec_args_tr(Rest, [Arg | Acc], RecFunInfo, ToList, FoundListInst,
 			   Pos+1).
 
--spec get_group(pos_integer(), rec_arg_lens()) -> pos_integer().
+-spec get_group(pos_integer(), [non_neg_integer()]) -> pos_integer().
 get_group(Pos, AllMembers) ->
     get_group_tr(Pos, AllMembers, 1).
 
--spec get_group_tr(pos_integer(), rec_arg_lens(), pos_integer()) ->
+-spec get_group_tr(pos_integer(), [non_neg_integer()], pos_integer()) ->
 	  pos_integer().
 get_group_tr(Pos, [Members | Rest], GroupNum) ->
     case Pos =< Members of

--- a/src/proper_typeserver.erl
+++ b/src/proper_typeserver.erl
@@ -1,7 +1,7 @@
 %%% -*- coding: utf-8 -*-
 %%% -*- erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
+%%% Copyright 2010-2018 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
 %%%
@@ -20,7 +20,7 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2010-2017 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
+%%% @copyright 2010-2018 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}
 %%% @author Manolis Papadakis
 
@@ -251,8 +251,9 @@
 -type rec_arg() :: {boolean() | {'list',boolean(),rec_fun()},full_type_ref()}.
 -type rec_args() :: [rec_arg()].
 -type ret_type() :: {'simple',fin_type()} | {'rec',rec_fun(),rec_args()}.
--type rec_fun_info() :: {pos_integer(),pos_integer(),[arity(),...],
-			 [rec_fun(),...]}.
+-type rec_arg_lens() :: [arity(),...].
+-type rec_funs()     :: [rec_fun(),...].
+-type rec_fun_info() :: {pos_integer(),pos_integer(),rec_arg_lens(),rec_funs()}.
 
 -type imm_type_ref() :: {type_name(),arity()}.
 -type hard_adt_repr() :: {abs_type(),[var_name()]} | 'already_declared'.
@@ -2309,11 +2310,11 @@ soft_clean_rec_args_tr([Arg | Rest], Acc, RecFunInfo, ToList, FoundListInst,
     soft_clean_rec_args_tr(Rest, [Arg | Acc], RecFunInfo, ToList, FoundListInst,
 			   Pos+1).
 
--spec get_group(pos_integer(), [non_neg_integer()]) -> pos_integer().
+-spec get_group(pos_integer(), rec_arg_lens()) -> pos_integer().
 get_group(Pos, AllMembers) ->
     get_group_tr(Pos, AllMembers, 1).
 
--spec get_group_tr(pos_integer(), [non_neg_integer()], pos_integer()) ->
+-spec get_group_tr(pos_integer(), rec_arg_lens(), pos_integer()) ->
 	  pos_integer().
 get_group_tr(Pos, [Members | Rest], GroupNum) ->
     case Pos =< Members of

--- a/src/proper_unicode.erl
+++ b/src/proper_unicode.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2014 Motiejus Jakstys <desired.mta@gmail.com>
 %%%
 %%% This file is part of PropEr.

--- a/src/proper_unused_imports_remover.erl
+++ b/src/proper_unused_imports_remover.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2015-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
@@ -123,4 +126,3 @@ add_new_attribute({Line, Mod, Fun}, [{_, Line, _, {Mod, FunL}} | Attributes]) ->
     [{attribute, Line, import, {Mod, [Fun | FunL]}} | Attributes];
 add_new_attribute({Line, Mod, Fun}, Attributes) ->
     [{attribute, Line, import, {Mod, [Fun]}} | Attributes].
-

--- a/src/vararg.erl
+++ b/src/vararg.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2016 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/auto_export_test1.erl
+++ b/test/auto_export_test1.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/auto_export_test2.erl
+++ b/test/auto_export_test2.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/command_props.erl
+++ b/test/command_props.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2016 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/error_statem.erl
+++ b/test/error_statem.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/ets_counter.erl
+++ b/test/ets_counter.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/ets_statem.erl
+++ b/test/ets_statem.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2014 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/exists_tests.erl
+++ b/test/exists_tests.erl
@@ -1,7 +1,7 @@
-%%% coding: latin-1
+%%% -*- coding: utf-8 -*-
 %%% -*- erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright (c) 2018, Andreas Löscher <andreas.loscher@it.uu.se>
+%%% Copyright (c) 2018, Andreas LÃ¶scher <andreas.loscher@it.uu.se>
 %%%                and  Konstantinos Sagonas <kostis@it.uu.se>
 %%%
 %%% This file is part of PropEr.
@@ -19,9 +19,9 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2017 Andreas Löscher and Kostis Sagonas
+%%% @copyright 2017 Andreas LÃ¶scher and Kostis Sagonas
 %%% @version {@version}
-%%% @author Andreas Löscher
+%%% @author Andreas LÃ¶scher
 
 -module(exists_tests).
 
@@ -99,33 +99,33 @@ forall_targeted_test() ->
 integer_test() ->
   put(proper_sa_testing, true),
   proper:global_state_init_size(10),
-  proper_sa_gen:init(),
+  proper_gen_next:init(),
   Gen = proper_types:integer(),
-  #{next := TG} = proper_sa_gen:from_proper_generator(Gen),
+  #{next := TG} = proper_gen_next:from_proper_generator(Gen),
   %% apply the generator 100 times and check that nothing crashes
   appl(TG, 0, 100),
-  proper_sa_gen:cleanup(),
+  proper_gen_next:cleanup(),
   ok.
 
 -spec list_test() -> 'ok'.
 list_test() ->
   put(proper_sa_testing, true),
   proper:global_state_init_size(10),
-  proper_sa_gen:init(),
+  proper_gen_next:init(),
   Gen = proper_types:list(atom),
-  #{next := TG} = proper_sa_gen:from_proper_generator(Gen),
+  #{next := TG} = proper_gen_next:from_proper_generator(Gen),
   %% apply the generator 100 times and check that nothing crashes
   appl(TG, [], 100),
-  proper_sa_gen:cleanup(),
+  proper_gen_next:cleanup(),
   ok.
 
 -spec combine_test() -> 'ok'.
 combine_test() ->
   put(proper_sa_testing, true),
   proper:global_state_init_size(10),
-  proper_sa_gen:init(),
+  proper_gen_next:init(),
   Gen = proper_types:list(proper_types:list(proper_types:integer())),
-  #{next := TG} = proper_sa_gen:from_proper_generator(Gen),
+  #{next := TG} = proper_gen_next:from_proper_generator(Gen),
   %% apply the generator 100 times and check that nothing crashes
   appl(TG, [], 100),
   ok.
@@ -417,7 +417,7 @@ matching_type() ->
   ?LET(I, integer(), I).
 
 prop_match() ->
-  ?FORALL_TARGETED(I, ?USERMATCHER(matching_type(), fun proper_sa_gen:match/3),
+  ?FORALL_TARGETED(I, ?USERMATCHER(matching_type(), fun proper_gen_next:match/3),
                    begin
                      ?MAXIMIZE(I),
                      I < 10

--- a/test/improper_lists_statem.erl
+++ b/test/improper_lists_statem.erl
@@ -1,10 +1,12 @@
-%%---------------------------------------------------------------------
-%% From Matthias Kretschmer
-%%
-%% I encountered the problem that I cannot have improper lists in my
-%% symbolic state. As I like to use a dictionary which might include
-%% improper lists, I made this little fix (#102).
-%%---------------------------------------------------------------------
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
+%%% From Matthias Kretschmer
+%%%
+%%% I encountered the problem that I cannot have improper lists in my
+%%% symbolic state. As I like to use a dictionary which might include
+%%% improper lists, I made this little fix (#102).
+%%%---------------------------------------------------------------------
 -module(improper_lists_statem).
 -export([command/1, initial_state/0, next_state/3,
 	 precondition/2, postcondition/3, foo/1]).

--- a/test/let_tests.erl
+++ b/test/let_tests.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2016 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/no_native_parse_test.erl
+++ b/test/no_native_parse_test.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/nogen_statem.erl
+++ b/test/nogen_statem.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/numbers_fsm.erl
+++ b/test/numbers_fsm.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/pdict_fsm.erl
+++ b/test/pdict_fsm.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2014 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/pdict_statem.erl
+++ b/test/pdict_statem.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2014 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/perf_max_size.erl
+++ b/test/perf_max_size.erl
@@ -1,28 +1,30 @@
-%%---------------------------------------------------------------------------
-%% From: Jeff Hlywa
-%% Subject: Increasing max_size significantly degrades performance.
-%%---------------------------------------------------------------------------
-%% Using the code below I get:
-%% 1> timer:tc(fun() ->
-%%      proper:quickcheck(perf_max_size:prop_identity(), [5, {max_size, 42}])
-%%    end).
-%% .....
-%% OK: Passed 5 test(s).
-%% {8170,true}
-%%
-%% 2> timer:tc(fun() ->
-%%      proper:quickcheck(perf_max_size:prop_identity(),
-%%                        [5, {max_size, 16#ffffffff}])
-%%    end).
-%% ....
-%% OK: Passed 5 test(s).
-%% {658751072,true}
-%%
-%% Not able to determine the cause of the slowdown, but it's significant.
-%% ---------------------------------------------------------------------------
-%% Fixed on 29/3/2013. The fix was that when increasing the size, move
-%% to the next value immediately instead of trying each value one-by-one.
-%% ---------------------------------------------------------------------------
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
+%%% From: Jeff Hlywa
+%%% Subject: Increasing max_size significantly degrades performance.
+%%% -------------------------------------------------------------------
+%%% Using the code below I get:
+%%% 1> timer:tc(fun() ->
+%%%      proper:quickcheck(perf_max_size:prop_identity(), [5, {max_size, 42}])
+%%%    end).
+%%% .....
+%%% OK: Passed 5 test(s).
+%%% {8170,true}
+%%%
+%%% 2> timer:tc(fun() ->
+%%%      proper:quickcheck(perf_max_size:prop_identity(),
+%%%                        [5, {max_size, 16#ffffffff}])
+%%%    end).
+%%% ....
+%%% OK: Passed 5 test(s).
+%%% {658751072,true}
+%%%
+%%% Not able to determine the cause of the slowdown, but it's significant.
+%%% -------------------------------------------------------------------
+%%% Fixed on 29/3/2013. The fix was that when increasing the size, move
+%%% to the next value immediately instead of trying each value one-by-one.
+%%% -------------------------------------------------------------------
 -module(perf_max_size).
 -export([prop_identity/0]).
 
@@ -41,4 +43,3 @@ encode(#msg{a = A, b = B}) ->
 -spec decode(bitstring()) -> msg().
 decode(<<A:32, B:4>>) ->
     #msg{a = A, b = B}.
-

--- a/test/post_false.erl
+++ b/test/post_false.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/prec_false.erl
+++ b/test/prec_false.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/proper_print.erl
+++ b/test/proper_print.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/proper_specs_tests.erl
+++ b/test/proper_specs_tests.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2015 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
@@ -1096,18 +1099,21 @@ setup_test_() ->
 	      andalso undefined =:= get(setup_token)
 	      andalso undefined =:= get(setup_token2))].
 
-adts_test_() ->
-    [{timeout, 20,	% for Kostis' old laptop
+adts1_test_() ->
+    {timeout, 60,	% for Kostis' old laptop
       ?_passes(?FORALL({X,S},{integer(),sets:set(integer())},
-		       sets:is_element(X,sets:add_element(X,S))), [20])},
-     {timeout, 40,	% for 18.x (and onwards?)
-      ?_passes(?FORALL({X,Y,D},
-		       {integer(),float(),dict:dict(integer(),float())},
-		       dict:fetch(X,dict:store(X,Y,eval(D))) =:= Y), [30])},
-     {timeout, 20,
+		       sets:is_element(X,sets:add_element(X,S))), [20])}.
+
+%% adts2_test_() -> {timeout, 60,	% for 18.x (and onwards?)
+%%       ?_passes(?FORALL({X,Y,D},
+%% 		       {integer(),float(),dict:dict(integer(),float())},
+%% 		       dict:fetch(X,dict:store(X,Y,eval(D))) =:= Y), [30])}.
+
+adts3_test_() ->
+     {timeout, 60,
       ?_fails(?FORALL({X,D},
 	      {boolean(),dict:dict(boolean(),integer())},
-	      dict:erase(X, dict:store(X,42,D)) =:= D))}].
+	      dict:erase(X, dict:store(X,42,D)) =:= D))}.
 
 parameter_test_() ->
     ?_passes(?FORALL(List, [zero1(),zero2(),zero3(),zero4()],

--- a/test/rec_props_test1.erl
+++ b/test/rec_props_test1.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/rec_props_test2.erl
+++ b/test/rec_props_test2.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/rec_test1.erl
+++ b/test/rec_test1.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/rec_test2.erl
+++ b/test/rec_test2.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/symb_statem.erl
+++ b/test/symb_statem.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/symb_statem_maps.erl
+++ b/test/symb_statem_maps.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2016-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/to_remove.erl
+++ b/test/to_remove.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/types_test1.erl
+++ b/test/types_test1.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/types_test2.erl
+++ b/test/types_test2.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/test/weird_types.erl
+++ b/test/weird_types.erl
@@ -1,3 +1,6 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2011 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>

--- a/write_compile_flags
+++ b/write_compile_flags
@@ -1,5 +1,8 @@
 #!/usr/bin/env escript
 
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
 %%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>


### PR DESCRIPTION
Changes:

+ change the encoding of the proper files from `latin1` to `utf-8`
+ consistent headers with encoding information
+ renamed `proper_sa_gen.erl` to `proper_gen_next.erl` and removed the dependency to `proper_sa.erl`